### PR TITLE
Update k8s deployment to use registry secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the LiteLLM Prometheus Exporter will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-07-28
+### Changed
+- Kubernetes Deployment pulls image from GHCR using `imagePullSecrets`
+- Updated README with instructions for creating the GHCR registry secret
+
+
 ## [1.0.0] - 2024-01-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.0.1] - 2025-07-28
 ### Changed
-- Kubernetes Deployment pulls image from GHCR using `imagePullSecrets`
-- Updated README with instructions for creating the GHCR registry secret
+- Kubernetes Deployment now pulls the container image from GHCR
+- Database credentials are provided via a Kubernetes Secret
 
 
 ## [1.0.0] - 2024-01-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Kubernetes Deployment now pulls the container image from GHCR
 - Database credentials are provided via a Kubernetes Secret
+- Deployment environment variables use `valueFrom.secretKeyRef`
 
 
 ## [1.0.0] - 2024-01-10

--- a/README.md
+++ b/README.md
@@ -151,15 +151,7 @@ echo -n "your-db-name" | base64
 echo -n "your-db-user" | base64
 echo -n "your-db-password" | base64
 ```
-2. Create a Docker registry secret named `ghcr-credentials` for pulling the image from GHCR:
-```bash
-kubectl create secret docker-registry ghcr-credentials \
-  --docker-server=ghcr.io \
-  --docker-username=<your-gh-username> \
-  --docker-password=<your-ghcr-token>
-```
-
-3. Update the Secret in `k8s/exporter-litellm.yaml` with your base64-encoded values:
+2. Update the Secret in `k8s/exporter-litellm.yaml` with your base64-encoded values:
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -173,7 +165,7 @@ data:
   LITELLM_DB_USER: "base64-encoded-user"
   LITELLM_DB_PASSWORD: "base64-encoded-password"
 ```
-4. Apply the Kubernetes manifests:
+3. Apply the Kubernetes manifests:
 ```bash
 kubectl apply -f k8s/exporter-litellm.yaml
 ```
@@ -181,7 +173,6 @@ kubectl apply -f k8s/exporter-litellm.yaml
 This will create:
 - A ConfigMap with exporter configuration
 - A Secret containing database credentials
-- A Secret for pulling the container image from GHCR
 - A Deployment running the exporter
 - A Service exposing the metrics endpoint
 

--- a/README.md
+++ b/README.md
@@ -151,8 +151,15 @@ echo -n "your-db-name" | base64
 echo -n "your-db-user" | base64
 echo -n "your-db-password" | base64
 ```
+2. Create a Docker registry secret named `ghcr-credentials` for pulling the image from GHCR:
+```bash
+kubectl create secret docker-registry ghcr-credentials \
+  --docker-server=ghcr.io \
+  --docker-username=<your-gh-username> \
+  --docker-password=<your-ghcr-token>
+```
 
-2. Update the Secret in `k8s/exporter-litellm.yaml` with your base64-encoded values:
+3. Update the Secret in `k8s/exporter-litellm.yaml` with your base64-encoded values:
 ```yaml
 apiVersion: v1
 kind: Secret
@@ -166,8 +173,7 @@ data:
   LITELLM_DB_USER: "base64-encoded-user"
   LITELLM_DB_PASSWORD: "base64-encoded-password"
 ```
-
-3. Apply the Kubernetes manifests:
+4. Apply the Kubernetes manifests:
 ```bash
 kubectl apply -f k8s/exporter-litellm.yaml
 ```
@@ -175,6 +181,7 @@ kubectl apply -f k8s/exporter-litellm.yaml
 This will create:
 - A ConfigMap with exporter configuration
 - A Secret containing database credentials
+- A Secret for pulling the container image from GHCR
 - A Deployment running the exporter
 - A Service exposing the metrics endpoint
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ data:
   LITELLM_DB_USER: "base64-encoded-user"
   LITELLM_DB_PASSWORD: "base64-encoded-password"
 ```
+The Deployment uses `valueFrom.secretKeyRef` to inject these credentials into
+the container's environment.
 3. Apply the Kubernetes manifests:
 ```bash
 kubectl apply -f k8s/exporter-litellm.yaml

--- a/k8s/exporter-litellm.yaml
+++ b/k8s/exporter-litellm.yaml
@@ -24,14 +24,6 @@ data:
   LITELLM_DB_PASSWORD: ""  # echo -n "your-db-password" | base64
 
 ---
-apiVersion: v1
-kind: Secret
-metadata:
-  name: ghcr-credentials
-type: kubernetes.io/dockerconfigjson
-data:
-  .dockerconfigjson: ""  # echo -n '{"auths": {"ghcr.io": {"username": "<your-username>", "password": "<your-token>"}}}' | base64
----
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -51,8 +43,6 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
     spec:
-      imagePullSecrets:
-      - name: ghcr-credentials
       containers:
       - name: litellm-exporter
         image: ghcr.io/ncecere/exporter-litellm:v1.0.0

--- a/k8s/exporter-litellm.yaml
+++ b/k8s/exporter-litellm.yaml
@@ -22,6 +22,15 @@ data:
   LITELLM_DB_NAME: ""      # echo -n "your-db-name" | base64
   LITELLM_DB_USER: ""      # echo -n "your-db-user" | base64
   LITELLM_DB_PASSWORD: ""  # echo -n "your-db-password" | base64
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ghcr-credentials
+type: kubernetes.io/dockerconfigjson
+data:
+  .dockerconfigjson: ""  # echo -n '{"auths": {"ghcr.io": {"username": "<your-username>", "password": "<your-token>"}}}' | base64
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -42,9 +51,11 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9090"
     spec:
+      imagePullSecrets:
+      - name: ghcr-credentials
       containers:
       - name: litellm-exporter
-        image: nicholascecere/exporter-litellm:latest
+        image: ghcr.io/ncecere/exporter-litellm:v1.0.0
         ports:
         - containerPort: 9090
         envFrom:

--- a/k8s/exporter-litellm.yaml
+++ b/k8s/exporter-litellm.yaml
@@ -51,8 +51,32 @@ spec:
         envFrom:
         - configMapRef:
             name: litellm-exporter-config
-        - secretRef:
-            name: litellm-exporter-secrets
+        env:
+        - name: LITELLM_DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: litellm-exporter-secrets
+              key: LITELLM_DB_HOST
+        - name: LITELLM_DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: litellm-exporter-secrets
+              key: LITELLM_DB_PORT
+        - name: LITELLM_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: litellm-exporter-secrets
+              key: LITELLM_DB_NAME
+        - name: LITELLM_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: litellm-exporter-secrets
+              key: LITELLM_DB_USER
+        - name: LITELLM_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: litellm-exporter-secrets
+              key: LITELLM_DB_PASSWORD
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Summary
- add `ghcr-credentials` secret example to the Kubernetes manifest
- configure deployment to use `imagePullSecrets`
- document how to create the registry secret
- note changes in the changelog

## Testing
- `pre-commit run --files k8s/exporter-litellm.yaml README.md CHANGELOG.md` *(failed: command not found)*
- `pytest -q` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6887a6589c48832cbc2be7008bd85a7b