### PR TITLE
Update k8s deployment to read secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the LiteLLM Prometheus Exporter will be documented in thi
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2025-07-28
+### Changed
+- Kubernetes Deployment now pulls the container image from GHCR
+- Database credentials are provided via a Kubernetes Secret
+- Deployment environment variables use `valueFrom.secretKeyRef`
+
+
 ## [1.0.0] - 2024-01-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -151,7 +151,6 @@ echo -n "your-db-name" | base64
 echo -n "your-db-user" | base64
 echo -n "your-db-password" | base64
 ```
-
 2. Update the Secret in `k8s/exporter-litellm.yaml` with your base64-encoded values:
 ```yaml
 apiVersion: v1
@@ -166,7 +165,8 @@ data:
   LITELLM_DB_USER: "base64-encoded-user"
   LITELLM_DB_PASSWORD: "base64-encoded-password"
 ```
-
+The Deployment uses `valueFrom.secretKeyRef` to inject these credentials into
+the container's environment.
 3. Apply the Kubernetes manifests:
 ```bash
 kubectl apply -f k8s/exporter-litellm.yaml

--- a/k8s/exporter-litellm.yaml
+++ b/k8s/exporter-litellm.yaml
@@ -22,6 +22,7 @@ data:
   LITELLM_DB_NAME: ""      # echo -n "your-db-name" | base64
   LITELLM_DB_USER: ""      # echo -n "your-db-user" | base64
   LITELLM_DB_PASSWORD: ""  # echo -n "your-db-password" | base64
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -44,14 +45,38 @@ spec:
     spec:
       containers:
       - name: litellm-exporter
-        image: nicholascecere/exporter-litellm:latest
+        image: ghcr.io/ncecere/exporter-litellm:v1.0.0
         ports:
         - containerPort: 9090
         envFrom:
         - configMapRef:
             name: litellm-exporter-config
-        - secretRef:
-            name: litellm-exporter-secrets
+        env:
+        - name: LITELLM_DB_HOST
+          valueFrom:
+            secretKeyRef:
+              name: litellm-exporter-secrets
+              key: LITELLM_DB_HOST
+        - name: LITELLM_DB_PORT
+          valueFrom:
+            secretKeyRef:
+              name: litellm-exporter-secrets
+              key: LITELLM_DB_PORT
+        - name: LITELLM_DB_NAME
+          valueFrom:
+            secretKeyRef:
+              name: litellm-exporter-secrets
+              key: LITELLM_DB_NAME
+        - name: LITELLM_DB_USER
+          valueFrom:
+            secretKeyRef:
+              name: litellm-exporter-secrets
+              key: LITELLM_DB_USER
+        - name: LITELLM_DB_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: litellm-exporter-secrets
+              key: LITELLM_DB_PASSWORD
         resources:
           requests:
             cpu: 100m


### PR DESCRIPTION
## Summary
- use `valueFrom.secretKeyRef` for DB credentials in the deployment
- document secret injection in README
- note secretKeyRef usage in changelog

## Testing
- `pre-commit run --files k8s/exporter-litellm.yaml README.md CHANGELOG.md` *(failed: command not found)*
- `pytest -q` *(no tests found)*


------
https://chatgpt.com/codex/tasks/task_e_6887a6589c48832cbc2be7008bd85a7b